### PR TITLE
Implement interruptible sail hoisting with configurable notifications

### DIFF
--- a/AutoSailsControlSail.cs
+++ b/AutoSailsControlSail.cs
@@ -9,13 +9,16 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace AutoSails
 {
+    public enum HoistDirection { Set, Furl }
+    public enum RopeOperation { Pull, Release }
+
     public class AutoSailsControlSail : MonoBehaviour
     {
 
         private Sail sail;
         private RopeController hoistWinch;
         private GPButtonRopeWinch hoistButton;
-        private List<GPButtonRopeWinch> angleButtons = [];
+        private List<GPButtonRopeWinch> angleButtons = new List<GPButtonRopeWinch>();
         private Queue<float> sailAngles = new Queue<float>();
         private const int maxSailAngles = 50;
 
@@ -40,6 +43,7 @@ namespace AutoSails
                                                // float hoistSign = -1;  // This is used to determine the direction of the hoist, depending on the sail type
                                                //TODO on some ships, the hoist Sign calculation does not work properly. Why?
         private bool reverseReefing = false;
+        private HoistDirection? nextHoistDirection = null; // Direction for next hoist operation (set on first use)
         private float trimDirection = -1f; // This is used to determine the direction of the trim
         private float oldEfficiency = 1f;
         private int i = 0;
@@ -75,7 +79,49 @@ namespace AutoSails
             {
                 if (AutoSailsMain.hoistSails.Value.IsDown() && canControl)
                 {
-                    hoistSails = !hoistSails;
+                    // Initialize direction on first use based on current sail state
+                    if (!nextHoistDirection.HasValue)
+                    {
+                        // Simple logic: if sail is currently set (hoisted), we want to furl it. If furled, we want to set it.
+                        nextHoistDirection = hoisted ? HoistDirection.Furl : HoistDirection.Set;
+                    }
+
+                    if (hoistSails)
+                    {
+                        // Currently hoisting - interrupt and handle based on resume behavior
+                        if (AutoSailsMain.resumeHoisting.Value == ResumeHoistingBehavior.OppositeDirection)
+                        {
+                            nextHoistDirection = (nextHoistDirection == HoistDirection.Set) ? HoistDirection.Furl : HoistDirection.Set;
+                        }
+                        // SameDirection mode: keep nextHoistDirection unchanged
+                        hoistSails = false;
+                        
+                        // UI element for interrupting
+                        if (AutoSailsMain.autoSailsUI.Value)
+                        {
+                            string message = GetNotificationMessage(AutoSailsMain.notificationStyle.Value, "pause");
+                            if (message != null)
+                            {
+                                NotificationUi.instance.ShowNotification(message);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Start hoisting in determined direction
+                        hoistSails = true;
+                        
+                        // UI elements for starting
+                        if (AutoSailsMain.autoSailsUI.Value)
+                        {
+                            string action = (nextHoistDirection == HoistDirection.Set) ? "set" : "furl";
+                            string message = GetNotificationMessage(AutoSailsMain.notificationStyle.Value, action);
+                            if (message != null)
+                            {
+                                NotificationUi.instance.ShowNotification(message);
+                            }
+                        }
+                    }
 
                     // for simplification, all sails use the same hotkey
                     hoistSailsSquare = hoistSails;
@@ -84,20 +130,6 @@ namespace AutoSails
                     hoistSailsGaff = hoistSails;
                     hoistSailsOther = hoistSails;
                     hoistSailsStaysail = hoistSails;
-
-                    // UI elements
-                    if (AutoSailsMain.autoSailsUI.Value)
-                    {
-                        if (hoisted)
-                        {
-                            NotificationUi.instance.ShowNotification("Lower the sails!");
-                        }
-                        else
-                        {
-                            NotificationUi.instance.ShowNotification("Hoist the sails!");
-                            
-                        }
-                    }
                 }
                 if (AutoSailsMain.trimSails.Value.IsDown() && canControl)
                 {
@@ -219,35 +251,38 @@ namespace AutoSails
             if (!sail || !hoistWinch || !hoistButton) return;
 
             // Overlays for debug
-            if (hoistButton.IsLookedAt() || hoistButton.IsStickyClicked() || hoistButton.IsCliked())
+            if (AutoSailsMain.showDebugInfo.Value && (hoistButton.IsLookedAt() || hoistButton.IsStickyClicked() || hoistButton.IsCliked()))
             {
                 hoistButton.description = "";
-                // hoistButton.description += $"\n Sail: {sail}";
-                // hoistButton.description += $"\n hoistWinch: {hoistWinch}";
-                // hoistButton.description += $"\n angleButtons: {angleButtons.Count}";
-                // hoistButton.description += $"\n canControl: {canControl}";
-                // hoistButton.description += $"\n Sail name: {sail.sailName}";
-                // hoistButton.description += $"\n squareSail: {sail.squareSail}";
-                // hoistButton.description += $"\n junkType: {sail.junkType}";
-                // // hoistButton.description += $"\n SailCategory: {sail.category}";
-                // hoistButton.description += $"\n reverseReefing: {reverseReefing}";
-                // hoistButton.description += $"\n hoisted: {hoisted}";
-                // hoistButton.description += $"\n hoistSails: {hoistSails}";
-                // hoistButton.description += $"\n currentLength: {hoistButton.rope.currentLength}";
-                // hoistButton.description += reverseReefing && hoistButton.rope.currentLength == 0;
-                // hoistButton.description += !reverseReefing && hoistButton.rope.currentLength == 1;
-                // hoistButton.description += !reverseReefing && hoistButton.rope.currentLength == 1;
-                // hoistButton.description += reverseReefing && hoistButton.rope.currentLength == 0;
-                // hoistButton.description += $"\n {hoisted}";
-                // hoistButton.description += $"\n {reverseReefing}";
-                // hoistButton.description += $"\n {hoistButton.rope.currentLength}";
-                
-                 
-                
+                hoistButton.description += $"\n Sail: {sail}";
+                hoistButton.description += $"\n hoistWinch: {hoistWinch}";
+                hoistButton.description += $"\n angleButtons: {angleButtons.Count}";
+                hoistButton.description += $"\n canControl: {canControl}";
+                hoistButton.description += $"\n Sail name: {sail.sailName}";
+                hoistButton.description += $"\n squareSail: {sail.squareSail}";
+                hoistButton.description += $"\n junkType: {sail.junkType}";
+                hoistButton.description += $"\n SailCategory: {sail.category}";
+                hoistButton.description += $"\n reverseReefing: {reverseReefing}";
+                hoistButton.description += $"\n hoisted: {hoisted}";
+                hoistButton.description += $"\n hoistSails: {hoistSails}";
+                hoistButton.description += $"\n currentLength: {hoistButton.rope.currentLength}";
+                hoistButton.description += $"\n nextHoistDirection: {nextHoistDirection}";
             }
             if (hoistSails)
             {
-                PerformHoist(reverseReefing ^ hoisted); // XOR to determine direction
+                // Convert nextHoistDirection to rope operation using original XOR logic
+                bool up;
+                if (nextHoistDirection.Value == HoistDirection.Set)
+                {
+                    // Setting: equivalent to when hoisted=false, so up = reverseReefing
+                    up = reverseReefing;
+                }
+                else // Furl
+                {
+                    // Furling: equivalent to when hoisted=true, so up = !reverseReefing
+                    up = !reverseReefing;
+                }
+                PerformHoist(up);
             }
             else if ( // if this is true sail is fully hoisted
                 (reverseReefing && hoistButton.rope.currentLength < 1)
@@ -268,20 +303,23 @@ namespace AutoSails
 
 
             // Overlays for debug
-            // foreach (GPButtonRopeWinch winchButton in angleButtons)
-            // {
-            //     string windSide = Vector3.SignedAngle(boat.transform.forward, sail.apparentWind, Vector3.up) < 0 ? "starboard" : "port";
-            //     winchButton.description = "";
-            //     winchButton.description += $"\n SailDegree: {SailDegree()}";
-            //     winchButton.description += $"\n windSide: {windSide}";
-            //     winchButton.description += $"\n winchButton.rope.currentLength: {winchButton.rope.currentLength}";
-            //     winchButton.description += $"\n CombinedEfficiency(): {CombinedEfficiency():F2}";
-            //     winchButton.description += $"\n SailEfficiency(): {SailEfficiency():F2}";
-            //     winchButton.description += $"\n SailInefficiency(): {SailInefficiency():F2}";
-            //     winchButton.description += $"\n ApparentWind: {Vector3.SignedAngle(-boat.transform.forward, sail.apparentWind, Vector3.up)}";
-            //     winchButton.description += $"\n AngleStandardDeviation: {AngleStandardDeviation():F4}";
-            //     winchButton.description += $"\n Windangle: {Vector3.SignedAngle(boat.transform.forward, sail.apparentWind, Vector3.up):F4}";
-            // }
+            if (AutoSailsMain.showDebugInfo.Value)
+            {
+                foreach (GPButtonRopeWinch winchButton in angleButtons)
+                {
+                    string windSide = Vector3.SignedAngle(boat.transform.forward, sail.apparentWind, Vector3.up) < 0 ? "starboard" : "port";
+                    winchButton.description = "";
+                    winchButton.description += $"\n SailDegree: {SailDegree()}";
+                    winchButton.description += $"\n windSide: {windSide}";
+                    winchButton.description += $"\n winchButton.rope.currentLength: {winchButton.rope.currentLength}";
+                    winchButton.description += $"\n CombinedEfficiency(): {CombinedEfficiency():F2}";
+                    winchButton.description += $"\n SailEfficiency(): {SailEfficiency():F2}";
+                    winchButton.description += $"\n SailInefficiency(): {SailInefficiency():F2}";
+                    winchButton.description += $"\n ApparentWind: {Vector3.SignedAngle(-boat.transform.forward, sail.apparentWind, Vector3.up)}";
+                    winchButton.description += $"\n AngleStandardDeviation: {AngleStandardDeviation():F4}";
+                    winchButton.description += $"\n Windangle: {Vector3.SignedAngle(boat.transform.forward, sail.apparentWind, Vector3.up):F4}";
+                }
+            }
             if (trimSails && hoisted)
             {
                 string windSide = Vector3.SignedAngle(boat.transform.forward, sail.apparentWind, Vector3.up) < 0 ? "starboard" : "port";
@@ -372,7 +410,7 @@ namespace AutoSails
                                 && (windSide == "port")
                                 )
                         {
-                            winchButton.description += "\nleft";
+                            // winchButton.description += "\nleft";
                             PrimitiveSailControl(winchButton);
                         }
                         else if (
@@ -381,7 +419,7 @@ namespace AutoSails
                             )
                         {
                             PrimitiveSailControl(winchButton);
-                            winchButton.description += "right";
+                            // winchButton.description += "right";
                         }
                         else
                         {
@@ -563,6 +601,8 @@ namespace AutoSails
             if (Mathf.Approximately(prevLength, hoistWinch.currentLength) ||
                 hoistWinch.currentLength == 0f || hoistWinch.currentLength == 1f)
             {
+                // Flip to opposite direction for next time (automatic reversal at limits)
+                nextHoistDirection = (nextHoistDirection == HoistDirection.Set) ? HoistDirection.Furl : HoistDirection.Set;
                 hoistSails = false;
             }
         }
@@ -584,6 +624,88 @@ namespace AutoSails
         {
             if (sailAngles.Count == 0) return 0f;
             return sailAngles.Average();
+        }
+
+        private static string GetNotificationMessage(NotificationStyle style, string action)
+        {
+            System.Random random = new System.Random();
+            
+            switch (style)
+            {
+                case NotificationStyle.None:
+                    return null; // No message
+                    
+                case NotificationStyle.Computer:
+                    switch (action)
+                    {
+                        case "set": return "Setting all sails";
+                        case "furl": return "Furling all sails";  
+                        case "pause": return "Sail operation paused";
+                    }
+                    break;
+                    
+                case NotificationStyle.ModernCaptain:
+                    switch (action)
+                    {
+                        case "set": 
+                            string[] setModern = { 
+                                "All hands! Set all sails!", 
+                                "Deploy all canvas!", 
+                                "Get every sail out there!",
+                                "Set all our canvas, crew!"
+                            };
+                            return setModern[random.Next(setModern.Length)];
+                        case "furl":
+                            string[] furlModern = { 
+                                "Furl all sails!", 
+                                "Bring in all canvas!",
+                                "Stow every sail!",
+                                "Take in all sails, now!"
+                            };
+                            return furlModern[random.Next(furlModern.Length)];
+                        case "pause":
+                            string[] pauseModern = { 
+                                "Belay that order!", 
+                                "Hold fast on the sails!",
+                                "Stop work on the canvas!",
+                                "Pause sail operations!"
+                            };
+                            return pauseModern[random.Next(pauseModern.Length)];
+                    }
+                    break;
+                    
+                case NotificationStyle.HistoricalCaptain:
+                    switch (action)
+                    {
+                        case "set":
+                            string[] setHistorical = { 
+                                "All hands aloft! Make sail!", 
+                                "Loose and set all canvas!",
+                                "Bear a hand and set every sail!",
+                                "Shake out all reefs and make sail!"
+                            };
+                            return setHistorical[random.Next(setHistorical.Length)];
+                        case "furl":
+                            string[] furlHistorical = { 
+                                "Hand the canvas! Strike all sail!", 
+                                "Clew up and furl all canvas!",
+                                "Take in every sail!",
+                                "Douse all canvas, lads!"
+                            };
+                            return furlHistorical[random.Next(furlHistorical.Length)];
+                        case "pause":
+                            string[] pauseHistorical = { 
+                                "Avast! Belay that last!", 
+                                "Hold fast, men!",
+                                "Stay your hand on the canvas!",
+                                "Vast heaving!"
+                            };
+                            return pauseHistorical[random.Next(pauseHistorical.Length)];
+                    }
+                    break;
+            }
+            
+            return null; // No default message
         }
     }
 }

--- a/AutoSailsMain.cs
+++ b/AutoSailsMain.cs
@@ -8,6 +8,20 @@ using UnityEngine;
 
 namespace AutoSails {
 
+    public enum ResumeHoistingBehavior
+    {
+        SameDirection,
+        OppositeDirection
+    }
+
+    public enum NotificationStyle
+    {
+        None,
+        Computer,
+        ModernCaptain,
+        HistoricalCaptain
+    }
+
     [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
     public class AutoSailsMain : BaseUnityPlugin
     {
@@ -16,6 +30,9 @@ namespace AutoSails {
         internal static ConfigEntry<KeyboardShortcut> trimSails;
         internal static ConfigEntry<bool> autoSailsUI;
         internal static ConfigEntry<bool> autoSailsAutoJibe;
+        internal static ConfigEntry<ResumeHoistingBehavior> resumeHoisting;
+        internal static ConfigEntry<NotificationStyle> notificationStyle;
+        internal static ConfigEntry<bool> showDebugInfo;
         public void Awake()
         {
             // Plugin startup logic
@@ -24,6 +41,9 @@ namespace AutoSails {
             trimSails = Config.Bind("Hotkeys", "Trim Sails Key", new KeyboardShortcut(KeyCode.J));
             autoSailsUI = Config.Bind("UI", "autoSailsUI", false, "Enables or disables the AutoSails UI. Requires restarting the game.");
             autoSailsAutoJibe = Config.Bind("Feature", "autoSailsAutoJibe", true, "Enables or disables the automatic jibing. Automatic jibing makes it hard to sail on a run and might not work on all ships. Requires restarting the game.");
+            resumeHoisting = Config.Bind("Feature", "Resume Hoisting", ResumeHoistingBehavior.OppositeDirection, "Controls behavior when resuming from paused hoist. 'Same Direction' continues original movement (classic behavior), 'Opposite Direction' reverses like a garage door opener.");
+            notificationStyle = Config.Bind("UI", "Notification Style", NotificationStyle.Computer, "Style of notification messages. 'None' disables notifications, 'Computer' uses technical language, 'Modern Captain' uses modern nautical commands, 'Historical Captain' uses 17th century nautical commands.");
+            showDebugInfo = Config.Bind("Debug", "Show Debug Info", false, "Shows debug information on sail controls when looking at them. For development use only.");
 
             //PATCHES INFO
             Harmony harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);


### PR DESCRIPTION
## Summary
- Implements garage door style sail hoisting: press to start, press to pause, press to resume in opposite direction (configurable)
- Adds configurable notification styles with authentic nautical terminology
- Simplifies architecture while preserving all proven rope movement logic
- Improves UI clarity with functional sail terminology (Set/Furl vs Hoist/Lower)

## Key Features
- **Interruptible hoisting**: Press hoist key during operation to pause, press again to resume
- **Configurable resume behavior**: Choose between SameDirection (classic) or OppositeDirection (garage door style)
- **Four notification styles**: None, Computer, Modern Captain, Historical Captain with randomized messages
- **Unified sail control**: All sails move together regardless of reverse reefing configuration
- **Debug system**: Simple on/off toggle for development debugging

## Technical Improvements
- Uses `nextHoistDirection` enum (Set/Furl) for clear functional representation
- Preserves original proven XOR logic for rope movement: `reverseReefing ^ hoisted`
- Clean separation between sail function (what user wants) and rope physics (how it works)
- Backward compatible with existing configuration

## Configuration Options
- `Resume Hoisting`: SameDirection | OppositeDirection (default: OppositeDirection)
- `Notification Style`: None | Computer | ModernCaptain | HistoricalCaptain (default: Computer)  
- `Show Debug Info`: Enable/disable debug overlays (default: false)

## Test Plan
- [x] Story 1: Press key once, sails continue until complete (preserved functionality)
- [x] Story 2: Press key during hoisting to pause immediately
- [x] Story 3: After pause, press key reverses direction (garage door style)
- [x] Story 4: Configure SameDirection mode for classic behavior
- [x] Story 5: When fully hoisted, press key starts furling
- [x] Story 7: Automatic stop and direction flip at rope limits
- [x] Notification styles work correctly for all sail types including reverse-reefed
- [x] Debug information displays correctly when enabled

Created with support from [Claude Code](https://claude.ai/code).