### PR TITLE
Implement interruptible sail hoisting with configurable notifications

### DIFF
--- a/AutoSailsMain.cs
+++ b/AutoSailsMain.cs
@@ -8,6 +8,20 @@ using UnityEngine;
 
 namespace AutoSails {
 
+    public enum ResumeHoistingBehavior
+    {
+        SameDirection,
+        OppositeDirection
+    }
+
+    public enum NotificationStyle
+    {
+        None,
+        Computer,
+        ModernCaptain,
+        HistoricalCaptain
+    }
+
     [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
     public class AutoSailsMain : BaseUnityPlugin
     {
@@ -16,6 +30,9 @@ namespace AutoSails {
         internal static ConfigEntry<KeyboardShortcut> trimSails;
         internal static ConfigEntry<bool> autoSailsUI;
         internal static ConfigEntry<bool> autoSailsAutoJibe;
+        internal static ConfigEntry<ResumeHoistingBehavior> resumeHoisting;
+        internal static ConfigEntry<NotificationStyle> notificationStyle;
+        internal static ConfigEntry<bool> showDebugInfo;
         public void Awake()
         {
             // Plugin startup logic
@@ -24,6 +41,9 @@ namespace AutoSails {
             trimSails = Config.Bind("Hotkeys", "Trim Sails Key", new KeyboardShortcut(KeyCode.J));
             autoSailsUI = Config.Bind("UI", "autoSailsUI", false, "Enables or disables the AutoSails UI. Requires restarting the game.");
             autoSailsAutoJibe = Config.Bind("Feature", "autoSailsAutoJibe", true, "Enables or disables the automatic jibing. Automatic jibing makes it hard to sail on a run and might not work on all ships. Requires restarting the game.");
+            resumeHoisting = Config.Bind("Feature", "Resume Hoisting", ResumeHoistingBehavior.OppositeDirection, "Controls behavior when resuming from paused hoist. 'Same Direction' continues original movement (classic behavior), 'Opposite Direction' reverses like a garage door opener.");
+            notificationStyle = Config.Bind("UI", "Notification Style", NotificationStyle.Computer, "Style of notification messages. 'None' disables notifications, 'Computer' uses technical language, 'Modern Captain' uses modern nautical commands, 'Historical Captain' uses 17th century nautical commands.");
+            showDebugInfo = Config.Bind("Debug", "Show Debug Info", false, "Shows debug information on sail controls when looking at them. For development use only.");
 
             //PATCHES INFO
             Harmony harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);


### PR DESCRIPTION
## Summary
- Implements garage door style sail hoisting: press to start, press to pause, press to resume in opposite direction (configurable)
- Adds configurable notification styles with authentic nautical terminology
- Simplifies architecture while preserving all proven rope movement logic
- Improves UI clarity with functional sail terminology (Set/Furl vs Hoist/Lower)

## Key Features
- **Interruptible hoisting**: Press hoist key during operation to pause, press again to resume
- **Configurable resume behavior**: Choose between SameDirection (classic) or OppositeDirection (garage door style)
- **Four notification styles**: None, Computer, Modern Captain, Historical Captain with randomized messages
- **Unified sail control**: All sails move together regardless of reverse reefing configuration
- **Debug system**: Simple on/off toggle for development debugging

## Technical Improvements
- Uses `nextHoistDirection` enum (Set/Furl) for clear functional representation
- Preserves original proven XOR logic for rope movement: `reverseReefing ^ hoisted`
- Clean separation between sail function (what user wants) and rope physics (how it works)
- Backward compatible with existing configuration

## Configuration Options
- `Resume Hoisting`: SameDirection | OppositeDirection (default: OppositeDirection)
- `Notification Style`: None | Computer | ModernCaptain | HistoricalCaptain (default: Computer)  
- `Show Debug Info`: Enable/disable debug overlays (default: false)

## Test Plan
- [x] Story 1: Press key once, sails continue until complete (preserved functionality)
- [x] Story 2: Press key during hoisting to pause immediately
- [x] Story 3: After pause, press key reverses direction (garage door style)
- [x] Story 4: Configure SameDirection mode for classic behavior
- [x] Story 5: When fully hoisted, press key starts furling
- [x] Story 7: Automatic stop and direction flip at rope limits
- [x] Notification styles work correctly for all sail types including reverse-reefed
- [x] Debug information displays correctly when enabled

Created with support from [Claude Code](https://claude.ai/code).